### PR TITLE
Reduce OpenEBS to local node storage

### DIFF
--- a/kubernetes/helm-chart-apps/openebs/appset-config.yaml
+++ b/kubernetes/helm-chart-apps/openebs/appset-config.yaml
@@ -2,4 +2,3 @@ helmChart: openebs
 helmChartVersion: 3.10.0
 helmChartURL: https://openebs.github.io/charts
 namespace: openebs
-valuesRevision: debug-openebs

--- a/kubernetes/helm-chart-apps/openebs/values.yaml
+++ b/kubernetes/helm-chart-apps/openebs/values.yaml
@@ -1,65 +1,64 @@
 fullnameOverride: openebs
+# localprovisioner:
+#   deviceClass:
+#     enabled: false
 
-localprovisioner:
-  deviceClass:
-    enabled: false
+#   basePath: /var/openebs/local
 
-  basePath: /var/openebs/local
+#   resources:
+#     requests:
+#       cpu: 15m
+#       memory: 50M
+#     limits:
+#       memory: 75M
 
-  resources:
-    requests:
-      cpu: 15m
-      memory: 50M
-    limits:
-      memory: 75M
+# ndm:
+#   resources:
+#     requests:
+#       cpu: 15m
+#       memory: 50M
+#     limits:
+#       memory: 75M
 
-ndm:
-  resources:
-    requests:
-      cpu: 15m
-      memory: 50M
-    limits:
-      memory: 75M
+# ndmOperator:
+#   resources:
+#     requests:
+#       cpu: 40m
+#       memory: 40M
+#     limits:
+#       memory: 60M
 
-ndmOperator:
-  resources:
-    requests:
-      cpu: 40m
-      memory: 40M
-    limits:
-      memory: 60M
+# jiva:
+#   enabled: true
+#   fullnameOverride: openebs-jiva
 
-jiva:
-  enabled: true
-  fullnameOverride: openebs-jiva
+#   jivaOperator:
+#     resources:
+#       requests:
+#         cpu: 1m
+#         memory: 60M
+#       limits:
+#         memory: 90M
 
-  jivaOperator:
-    resources:
-      requests:
-        cpu: 1m
-        memory: 60M
-      limits:
-        memory: 90M
+#   csiController:
+#     resources:
+#       requests:
+#         cpu: 5m
+#         memory: 40M
+#       limits:
+#         memory: 60M
 
-  csiController:
-    resources:
-      requests:
-        cpu: 5m
-        memory: 40M
-      limits:
-        memory: 60M
+#   csiNode:
+#     resources:
+#       requests:
+#         cpu: 10m
+#         memory: 40M
+#       limits:
+#         memory: 60M
 
-  csiNode:
-    resources:
-      requests:
-        cpu: 10m
-        memory: 40M
-      limits:
-        memory: 60M
+#   storageClass:
+#     name: openebs-jiva-csi-default
 
-  storageClass:
-    name: openebs-jiva-csi-default
-
-  defaultPolicy:
-    name: openebs-jiva-default-policy
-    replicas: 1
+#   defaultPolicy:
+#     name: openebs-jiva-default-policy
+#     replicas: 1

--- a/kubernetes/helm-chart-apps/openebs/values.yaml
+++ b/kubernetes/helm-chart-apps/openebs/values.yaml
@@ -16,37 +16,3 @@ ndm:
 
 ndmOperator:
   enabled: false
-# jiva:
-#   enabled: true
-#   fullnameOverride: openebs-jiva
-
-#   jivaOperator:
-#     resources:
-#       requests:
-#         cpu: 1m
-#         memory: 60M
-#       limits:
-#         memory: 90M
-
-#   csiController:
-#     resources:
-#       requests:
-#         cpu: 5m
-#         memory: 40M
-#       limits:
-#         memory: 60M
-
-#   csiNode:
-#     resources:
-#       requests:
-#         cpu: 10m
-#         memory: 40M
-#       limits:
-#         memory: 60M
-
-#   storageClass:
-#     name: openebs-jiva-csi-default
-
-#   defaultPolicy:
-#     name: openebs-jiva-default-policy
-#     replicas: 1

--- a/kubernetes/helm-chart-apps/openebs/values.yaml
+++ b/kubernetes/helm-chart-apps/openebs/values.yaml
@@ -1,25 +1,20 @@
 fullnameOverride: openebs
-# localprovisioner:
-#   deviceClass:
-#     enabled: false
 
-#   basePath: /var/openebs/local
+localprovisioner:
+  deviceClass:
+    enabled: false
 
-#   resources:
-#     requests:
-#       cpu: 15m
-#       memory: 50M
-#     limits:
-#       memory: 75M
+  basePath: /var/openebs/local
 
-# ndm:
-#   resources:
-#     requests:
-#       cpu: 15m
-#       memory: 50M
-#     limits:
-#       memory: 75M
+  resources:
+    requests:
+      cpu: 15m
+      memory: 50M
+    limits:
+      memory: 75M
 
+ndm:
+  enabled: false
 # ndmOperator:
 #   resources:
 #     requests:

--- a/kubernetes/helm-chart-apps/openebs/values.yaml
+++ b/kubernetes/helm-chart-apps/openebs/values.yaml
@@ -3,9 +3,7 @@ fullnameOverride: openebs
 localprovisioner:
   deviceClass:
     enabled: false
-
   basePath: /var/openebs/local
-
   resources:
     requests:
       cpu: 15m
@@ -15,14 +13,9 @@ localprovisioner:
 
 ndm:
   enabled: false
-# ndmOperator:
-#   resources:
-#     requests:
-#       cpu: 40m
-#       memory: 40M
-#     limits:
-#       memory: 60M
 
+ndmOperator:
+  enabled: false
 # jiva:
 #   enabled: true
 #   fullnameOverride: openebs-jiva


### PR DESCRIPTION
The cluster doesn't meet the minimum requirements for replicated storage. We can achieve this replication using a database service.